### PR TITLE
Use cmd-eikana instead of karabiner

### DIFF
--- a/roles/brewcask/defaults/main.yml
+++ b/roles/brewcask/defaults/main.yml
@@ -19,7 +19,6 @@ homebrew_cask_packages:
   - { name: google-chrome }
   - { name: google-japanese-ime }
   - { name: iterm2 }
-  - { name: karabiner }
   - { name: mysqlworkbench }
   - { name: sequel-pro }
   - { name: sublime-text }
@@ -35,6 +34,7 @@ homebrew_cask_packages:
   - { name: goofy }
   - { name: hyper }
   - { name: slack }
+  - { name: cmd-eikana }
   # Fonts
   # https://github.com/caskroom/homebrew-fonts/tree/master/Casks
   - { name: font-source-code-pro }


### PR DESCRIPTION
macOS SierraでKarabinerが動かなくて困っている人に贈る代替ソフトウェア
http://hitoriblog.com/?p=44850